### PR TITLE
Initial application module outputs

### DIFF
--- a/modules/application/outputs.tf
+++ b/modules/application/outputs.tf
@@ -1,5 +1,5 @@
 
-# output "aws_instances" {
-#   description = "AWS Instances."
-#   value       = { for instance in aws_instance.aws_instance.ec2 : instance.tags.Name => tomap({ "id" = subnet.id, "cidr_block" = subnet.cidr_block, "vpc_id" = subnet.vpc_id }) }
-# }
+output "aws_instances" {
+  description = "EC2 Instances."
+  value       = { for instance in aws_instance.ec2 : instance.tags.Name => tomap({ "ip" = instance.private_ip, "availability_zone" = instance.availability_zone, "subnet_id" = instance.subnet_id  }) }
+}


### PR DESCRIPTION
In this PR, **outputs** were added to the application modules, such that the **IPs** and other **EC2** instance information can be transparent.