### PR TITLE
Added route association to the outputs within the network module

### DIFF
--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -19,7 +19,7 @@ output "public_routes" {
   value       = { for route in aws_route_table.public : route.tags.Name => tomap({ "id" = route.id, "vpc_id" = route.vpc_id }) }
 }
 
-# output "route_table_associations" {
-#   description = "Route Table Associations."
-#   value       = { for rta in aws_route_table_association.rta : route.tags.Name => tomap({ "id" = rta.id, "vpc_id" = route.vpc_id }) }
-# }
+output "route_table_associations" {
+  description = "Route Table Associations."
+  value       = { for rta in aws_route_table_association.rta : rta.id => tomap({ "route_table_id" = rta.route_table_id, "subnet_id" = rta.subnet_id }) }
+}


### PR DESCRIPTION
In this PR, the _Network_ module outputs were updated to account for **Route Table Associations**.