### PR TITLE
Added VPC Security Groups to outputs

### DIFF
--- a/modules/application/outputs.tf
+++ b/modules/application/outputs.tf
@@ -1,5 +1,5 @@
 
 output "aws_instances" {
   description = "EC2 Instances."
-  value       = { for instance in aws_instance.ec2 : instance.tags.Name => tomap({ "ip" = instance.private_ip, "availability_zone" = instance.availability_zone, "subnet_id" = instance.subnet_id }) }
+  value       = { for instance in aws_instance.ec2 : instance.tags.Name => tomap({ "ip" = instance.private_ip, "availability_zone" = instance.availability_zone, "subnet_id" = instance.subnet_id, "security_group_ids" = jsonencode(instance.vpc_security_group_ids) }) }
 }


### PR DESCRIPTION
In this PR, the _VPC Security Group_ identifiers were added to the **Application** module's outputs.