### PR TITLE
Added AWS instance id to outputs in the Application module

### DIFF
--- a/modules/application/outputs.tf
+++ b/modules/application/outputs.tf
@@ -1,5 +1,5 @@
 
 output "aws_instances" {
   description = "EC2 Instances."
-  value       = { for instance in aws_instance.ec2 : instance.tags.Name => tomap({ "ip" = instance.private_ip, "availability_zone" = instance.availability_zone, "subnet_id" = instance.subnet_id, "security_group_ids" = jsonencode(instance.vpc_security_group_ids) }) }
+  value       = { for instance in aws_instance.ec2 : instance.tags.Name => tomap({ "id" = instance.id, "ip" = instance.private_ip, "availability_zone" = instance.availability_zone, "subnet_id" = instance.subnet_id, "security_group_ids" = jsonencode(instance.vpc_security_group_ids) }) }
 }

--- a/scripts/test_load_balancer.sh
+++ b/scripts/test_load_balancer.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# Test a Load Balancer.
+# 
+SITE_ADDRESS=$(terraform output site_address)
+
+watch curl -s $SITE_ADDRESS

--- a/tf_deploy_bellanov/main.tf
+++ b/tf_deploy_bellanov/main.tf
@@ -207,3 +207,27 @@ resource "aws_security_group" "web_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
+# resource "aws_elb" "web" {
+#   name = "web-elb"
+#   subnets = [ module.network.subnets["Public Subnet 1"].id, module.network.subnets["Public Subnet 2"].id ]
+#   security_groups = [aws_security_group.elb_sg.id]
+#   instances = [ module.application.aws_instances["Web Server 1"].id, module.application.aws_instances["Web Server 2"].id ]
+
+#   # Listen for HTTP requests and distribute them to the instances
+#   listener { 
+#     instance_port     = 80
+#     instance_protocol = "http"
+#     lb_port           = 80
+#     lb_protocol       = "http"
+#   }
+
+#   # Check instance health every 10 seconds
+#   health_check {
+#     healthy_threshold = 2
+#     unhealthy_threshold = 2
+#     timeout = 3
+#     target = "HTTP:80/"
+#     interval = 10
+#   }
+# }


### PR DESCRIPTION
In this PR, the **AWS Instance Id** was added to the outputs within the **Application** module such that it can be passed into the _Elastic Load Balancer_.